### PR TITLE
Updates to phantomquail.js to make it work with the dev branch of Quail

### DIFF
--- a/siteinspector/phantomquail.js
+++ b/siteinspector/phantomquail.js
@@ -69,6 +69,7 @@ page.open(address, function (status) {
         console.log('Running ' + testname + '...')
         jQuery.noConflict();
         var test = tests[testname];
+        // Basic test attributes.
         var output = {
           id: testname,
           title: test.title,
@@ -81,6 +82,7 @@ page.open(address, function (status) {
         jQuery('html').quail({
           accessibilityTests: tests,
           guideline: [testname],
+          // Called when an individual Case in a test is resolved.
           caseResolve: function (eventName, test, _case) {
             output.cases.push({
               status: _case.get('status'),
@@ -91,9 +93,7 @@ page.open(address, function (status) {
           testComplete: function (eventName, test) {},
           // Called when all the Tests in a TestCollection are completed.
           complete: function (eventName, testCollection) {
-            testCollection.each(function (index, test) {
-              //output += 'complete: ' + test.get('name');
-            });
+            // Push the results of the test out to the Phantom listener.
             if (typeof window.callPhantom === 'function') {
               window.callPhantom(JSON.stringify(output));
             }


### PR DESCRIPTION
This pull request will update the site monitor to work with the latest Quail release: 2.2.0.

https://github.com/quailjs/quail/tree/2.2.0

I've been running the test runner from the command line like this:

_All tests_

``` bash
phantomjs /usr/local/opt/siteinspector/phantomquail.js http://jessebeach.github.dev
```

_A single test_

``` bash
phantomjs /usr/local/opt/siteinspector/phantomquail.js http://jessebeach.github.dev aLinksDontOpenNewWindow
```

There is a `dir` variable in the file that you'll want to change to the correct resource path for your system.

Currently the results are written as JSON to a file called `results.js` in the `dir` directory. Feel free to change this file name and location.
