### PR TITLE
Case html

### DIFF
--- a/siteinspector/phantomquail.js
+++ b/siteinspector/phantomquail.js
@@ -105,7 +105,8 @@ page.open(address, function (status) {
           caseResolve: function (eventName, test, _case) {
             output.cases.push({
               status: _case.get('status'),
-              selector: _case.get('selector')
+              selector: _case.get('selector'),
+              html: _case.get('html')
             });
           },
           // Called when all the Cases in a Test are resolved.


### PR DESCRIPTION
Push the `html` Case property into the test results.

Runs agains the 2.2.1 tag of Quail.
