### PR TITLE
Changes to match the Quail 2.2.6 tag. Improvements to efficiency of JSON stringification and parsing out of PhantomJS.

### DIFF
--- a/siteinspector/phantomquail.js
+++ b/siteinspector/phantomquail.js
@@ -86,14 +86,6 @@ var testsdata = fs.read('/opt/quail/dist/tests.json');
 var allTests = JSON.parse(testsdata);
 var tests = {};
 
-// Only add the tests which are defined in the guidelines.
-for ( var i = 0 ; i < guidelines.length; i++) {
-  var key = guidelines[i];
-  if (allTests[key]) {
-    tests[key] = allTests[key];
-  }
-}
-
 // If a specific test is requested, just use that one.
 var testFromCLI = system.args[2];
 
@@ -101,6 +93,15 @@ if (testFromCLI && allTests[testFromCLI]) {
   var singleTest = allTests[testFromCLI];
   tests = {};
   tests[testFromCLI] = singleTest;
+}
+else if (guidelines.length) {
+  // Only add the tests which are defined in the guidelines.
+  for ( var i = 0 ; i < guidelines.length; i++) {
+    var key = guidelines[i];
+    if (allTests[key]) {
+      tests[key] = allTests[key];
+    }
+  }
 }
 else {
   tests = allTests;


### PR DESCRIPTION
Quail 2.2.5 now reports on all Success Criteria (19 total). Although not many are evaluating anything at the moment. 

I had to refactor the way we're pushing data out of the `phantomquail.js` file. It was redundantly stringifying all the test data (my fault) and when I added a few more Success Criteria, it was blowing up Phantom.

I also reduced the amount of HTML that a case will report. The limit is now a 200 char string. It will indicated if it is truncated, for example:

```
{
   "status": "passed",
  "selector": "script[type=\"text/javascript\"]",
  "html": "<script type=\"text/javascript\" style=\"visibility: visible; \">\t\t  var _gaq = _gaq || [];\t\t  _gaq.push(['_setAccount', 'UA-30992891-1']);\t\t  _gaq.push(['_trackPageview']);\t\t  (function() {\t\t    var ga =... [truncated]"
}
```

Also, the `html` and `body` elements now simply report `<HTML>` or `<BODY>` rather than their entire contents. That should _greatly_ reduce the size of the results files. We'll get more optimizations in their soon as well.
